### PR TITLE
feat: Serve the health path from the recording and replaying servers.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type EndpointConfig struct {
 	TargetPort                 int64               `yaml:"target_port"`
 	SourcePort                 int64               `yaml:"source_port"`
 	SourceType                 string              `yaml:"source_type"`
+	Health                     string              `yaml:"health"`
 	RedactRequestHeaders       []string            `yaml:"redact_request_headers"`
 	ResponseHeaderReplacements []HeaderReplacement `yaml:"response_header_replacements"`
 }

--- a/internal/record/recording_https_proxy.go
+++ b/internal/record/recording_https_proxy.go
@@ -64,6 +64,10 @@ func (r *RecordingHTTPSProxy) Start() error {
 }
 
 func (r *RecordingHTTPSProxy) handleRequest(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == r.config.Health {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 	fmt.Printf("Recording request: %s %s\n", req.Method, req.URL.String())
 
 	reqHash, err := r.recordRequest(req)

--- a/internal/replay/replay_http_server.go
+++ b/internal/replay/replay_http_server.go
@@ -56,6 +56,11 @@ func (r *ReplayHTTPServer) Start() error {
 }
 
 func (r *ReplayHTTPServer) handleRequest(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == r.config.Health {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	redactedReq, err := r.createRedactedRequest(req)
 	if err != nil {
 		fmt.Printf("Error processing request")


### PR DESCRIPTION
When a health check path is configured for an endpoint using the `health` key, test-server will respond to that path with a 200 HTTP status.