### PR TITLE
fix: Expect a leading `/` for health paths

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "test-server-sdk",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "test-server-sdk",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-server-sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TypeScript SDK for test-server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/typescript/sample/package-lock.json
+++ b/sdks/typescript/sample/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "test-server-sdk",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -115,9 +115,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/sdks/typescript/sample/test-data/config/test-server-config.yml
+++ b/sdks/typescript/sample/test-data/config/test-server-config.yml
@@ -4,4 +4,4 @@ endpoints:
     target_port: 443
     source_type: http
     source_port: 18080
-    health: healthz
+    health: /healthz

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -208,7 +208,7 @@ async function awaitHealthyTestServer(options: TestServerOptions): Promise<void>
       if (!("health" in endpoint)) {
         continue;
       }
-      const url = `${endpoint['source_type']}://localhost:${endpoint['source_port']}/${endpoint['health']}`
+      const url = `${endpoint['source_type']}://localhost:${endpoint['source_port']}${endpoint['health']}`
       await healthCheck(url);
     }
     return;


### PR DESCRIPTION
Before this change there was a mismatch between the typescript sdk - which was expecting the health path to be specified without the leading `/`, and the test-server binary - which was expecting a leading `/`.