### PR TITLE
feat: support record and replay websocket requests

### DIFF
--- a/internal/record/recording_https_proxy.go
+++ b/internal/record/recording_https_proxy.go
@@ -70,16 +70,16 @@ func (r *RecordingHTTPSProxy) handleRequest(w http.ResponseWriter, req *http.Req
 	}
 	fmt.Printf("Recording request: %s %s\n", req.Method, req.URL.String())
 
-	recReq, recErr := r.recordRequest(req)
-	if recErr != nil {
-		fmt.Printf("Error recording request: %v\n", recErr)
-		http.Error(w, fmt.Sprintf("Error recording request: %v", recErr), http.StatusInternalServerError)
+	recReq, err := r.recordRequest(req)
+	if err != nil {
+		fmt.Printf("Error recording request: %v\n", err)
+		http.Error(w, fmt.Sprintf("Error recording request: %v", err), http.StatusInternalServerError)
 		return
 	}
-	fileName, fileNameErr := recReq.GetRecordingFileName()
-	if fileNameErr != nil {
-		fmt.Printf("Invalid recording file name: %v\n", recErr)
-		http.Error(w, fmt.Sprintf("Invalid recording file name: %v", recErr), http.StatusInternalServerError)
+	fileName, err := recReq.GetRecordingFileName()
+	if err != nil {
+		fmt.Printf("Invalid recording file name: %v\n", err)
+		http.Error(w, fmt.Sprintf("Invalid recording file name: %v", err), http.StatusInternalServerError)
 		return
 	}
 
@@ -269,7 +269,7 @@ func pumpWebsocket(src, dst *websocket.Conn, c chan []byte, quit chan int, prepe
 			return
 		}
 		buf = append(buf, '\n')
-		prefix := fmt.Sprintf("%s%d", prepend, len(buf))
+		prefix := fmt.Sprintf("%s%d ", prepend, len(buf))
 		c <- append([]byte(prefix), buf...)
 		err = dst.WriteMessage(msgType, buf)
 		if err != nil {

--- a/internal/replay/replay_http_server.go
+++ b/internal/replay/replay_http_server.go
@@ -229,6 +229,7 @@ func replayWebsocket(conn *websocket.Conn, chunks []string) {
 			recChunk := string(runes[1:])
 			if reqChunk != recChunk {
 				fmt.Printf("input chunk mismatch\n Input chunk: %s\n Recorded chunk: %s\n", reqChunk, recChunk)
+				writeError(conn, "input chunk mismatch")
 				return
 			}
 		} else if strings.HasPrefix(chunk, "<") {
@@ -244,6 +245,17 @@ func replayWebsocket(conn *websocket.Conn, chunks []string) {
 			fmt.Printf("Unreconginized chunk: %s", chunk)
 			return
 		}
+	}
+}
+
+func writeError(conn *websocket.Conn, errMsg string) {
+	closeMessage := websocket.FormatCloseMessage(
+		websocket.CloseInternalServerErr,
+		errMsg,
+	)
+	err := conn.WriteMessage(websocket.CloseMessage, closeMessage)
+	if err != nil {
+		fmt.Printf("Failed to write error: %v\n", err)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -92,15 +92,19 @@ func (r *RecordedRequest) ComputeSum() string {
 	return hashHex
 }
 
-// GetRecordFileName returns the record file name.
+// GetRecordingFileName returns the recording file name.
 // It prefers the value from the TEST_NAME header.
-// If the TEST_NAME header is not present or its value is empty, it falls back to computed SHA256 sum.
-func (r *RecordedRequest) GetRecordFileName() string {
+// It returns error when test name contains illegal sequence.
+// If the TEST_NAME header is not present, it falls back to computed SHA256 sum.
+func (r *RecordedRequest) GetRecordingFileName() (string, error) {
 	testName := r.Header.Get("Test-Name")
-	if testName != "" {
-		return testName
+	if strings.Contains(testName, "../") {
+		return "", fmt.Errorf("test name: %s contains illegal sequence '../'", testName)
 	}
-	return r.ComputeSum()
+	if testName != "" {
+		return testName, nil
+	}
+	return r.ComputeSum(), nil
 }
 
 // Serialize the request.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -92,6 +92,17 @@ func (r *RecordedRequest) ComputeSum() string {
 	return hashHex
 }
 
+// GetRecordFileName returns the record file name.
+// It prefers the value from the TEST_NAME header.
+// If the TEST_NAME header is not present or its value is empty, it falls back to computed SHA256 sum.
+func (r *RecordedRequest) GetRecordFileName() string {
+	testName := r.Header.Get("Test-Name")
+	if testName != "" {
+		return testName
+	}
+	return r.ComputeSum()
+}
+
 // Serialize the request.
 //
 // The serialization format is as follows:

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,11 +85,22 @@ func readBody(req *http.Request) ([]byte, error) {
 }
 
 // ComputeSum computes the SHA256 sum of a RecordedRequest.
-func (r *RecordedRequest) ComputeSum() (string, error) {
+func (r *RecordedRequest) ComputeSum() string {
 	serialized := r.Serialize()
 	hash := sha256.Sum256([]byte(serialized))
 	hashHex := hex.EncodeToString(hash[:])
-	return hashHex, nil
+	return hashHex
+}
+
+// GetRecordFileName returns the record file name.
+// It prefers the value from the TEST_NAME header.
+// If the TEST_NAME header is not present or its value is empty, it falls back to computed SHA256 sum.
+func (r *RecordedRequest) GetRecordFileName() string {
+	testName := r.Header.Get("Test-Name")
+	if testName != "" {
+		return testName
+	}
+	return r.ComputeSum()
 }
 
 // Serialize the request.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -92,17 +92,6 @@ func (r *RecordedRequest) ComputeSum() string {
 	return hashHex
 }
 
-// GetRecordFileName returns the record file name.
-// It prefers the value from the TEST_NAME header.
-// If the TEST_NAME header is not present or its value is empty, it falls back to computed SHA256 sum.
-func (r *RecordedRequest) GetRecordFileName() string {
-	testName := r.Header.Get("Test-Name")
-	if testName != "" {
-		return testName
-	}
-	return r.ComputeSum()
-}
-
 // Serialize the request.
 //
 // The serialization format is as follows:

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -329,6 +329,68 @@ func TestRecordedRequest_Deserialize(t *testing.T) {
 	}
 }
 
+func TestRecordedRequest_GetRecordFileName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		request  RecordedRequest
+		expected string
+	}{
+		{
+			name: "Request with test name header",
+			request: RecordedRequest{
+				Request: "GET / HTTP/1.1",
+				Header: http.Header{
+					"Test-Name": []string{"random test name"},
+				},
+				Body:            []byte{},
+				PreviousRequest: HeadSHA,
+				ServerAddress:   "",
+				Port:            0,
+				Protocol:        "",
+			},
+			expected: "random test name",
+		},
+		{
+			name: "Request with empty test name header",
+			request: RecordedRequest{
+				Request: "GET / HTTP/1.1",
+				Header: http.Header{
+					"Test-Name": []string{""},
+				},
+				Body:            []byte{},
+				PreviousRequest: HeadSHA,
+				ServerAddress:   "",
+				Port:            0,
+				Protocol:        "",
+			},
+			expected: "f824dd099907ed4549822de827b075a7578baadebf08c5bc7303ead90a8f9ff7",
+		},
+		{
+			name: "Request without test name header",
+			request: RecordedRequest{
+				Request: "GET / HTTP/1.1",
+				Header: http.Header{
+					"Accept":       []string{"application/xml"},
+					"Content-Type": []string{"application/json"},
+				},
+				Body:            []byte{},
+				PreviousRequest: HeadSHA,
+				ServerAddress:   "",
+				Port:            0,
+				Protocol:        "",
+			},
+			expected: "fc060aea9a2bf35da16ed18c6be577ca64d0f91d681d5db385082df61ecf4ccf",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.request.GetRecordFileName()
+			require.Equal(t, tc.expected, actual, "GetRecordFileName() result mismatch")
+		})
+	}
+}
+
 type errorReader struct{}
 
 func (e *errorReader) Read(p []byte) (n int, err error) {


### PR DESCRIPTION
1. Update the record file name to prefer read the test name from header, and fallback to the sha256 name
2. The whole websocket session request and response chunks will be stored in one replay file