### PR TITLE
Make default config match usage docs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,5 +39,5 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ./test-server.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "test-server.yaml", "config file")
 }


### PR DESCRIPTION
The usage doc for the `config` flag was misleading.

Before it was documented as:
```
      --config string   config file (default is ./test-server.yaml)
```
but the actual default was an empty string.

After the change it is documented as:
```
      --config string   config file (default "test-server.yaml")
```
and the default is as described.