### PR TITLE
feat: Add GitHub Release workflow for Python SDK

### DIFF
--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -1,0 +1,45 @@
+# .github/workflows/release-python-sdk.yml
+
+name: Release Python SDK
+
+# This workflow runs when a tag starting with 'sdks/python/v' is pushed
+on:
+  push:
+    tags:
+      - 'sdks/python/v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    name: Build Python SDK artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install build dependencies
+        run: pip install build twine
+
+      - name: Build Python wheel and source distribution
+        run: python3 -m build
+        working-directory: ./sdks/python
+
+      - name: Create GitHub Release and Upload Artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          # This will upload all files from the build output directory
+          # (e.g., your-package-0.2.0-py3-none-any.whl and your-package-0.2.0.tar.gz)
+          files: sdks/python/dist/*
+          # This will create a draft release require teammate to manually publish, once
+          # we are confident with the release process, we can set draft: false, which
+          # will automatic create the release.
+          draft: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,3 +91,28 @@ After a new `test-server` binary is released, you need to update the checksums p
 6.  Publish the new version to npm following internal guidance at go/wombat-dressing-room. (When prompted,
     create a package specific publish token for  `test-server-sdk`.)
   
+### Release python sdk
+
+Publishing Python sdk is a relatively independent process, you can release python sdk without
+any change on golang `test-server` binary.
+
+1.  Ensure your local `main` branch is up-to-date and clean:
+    ```sh
+    git checkout main && git pull origin main && git clean -xdf
+    ```
+2. Update the version in `sdks/python/pyproject.toml`, create and merge the PR.
+    ```
+    git add .
+    git commit -m "chore: Prepare for Python SDK release v0.1.0"
+    git push origin release/python-v0.1.0
+    ```
+4. Find the current version of the python sdk in `sdks/python/pyproject.toml`. And
+   find the current golang test-server version, make sure 
+    `sdks/python/src/test-server-sdk/checksums.json` include this version.
+3.  Create and push a new version tag. For example, for version `sdks/python/v0.1.0-core.0.2.8`:
+    ```sh
+    git tag -a sdks/python/v0.1.0-core.0.2.8 -m "Release Python SDK v0.1.0 for Core v0.2.8"
+    git push origin sdks/python/v0.1.0-core.0.2.8
+    ```
+4. Find the draft release, verify the executable is built and uplaoaded successfully.
+5. Publish the relase


### PR DESCRIPTION
This PR introduces a new release process for the Python SDK, distributing it as a wheel file attached to GitHub Releases instead of publishing it to PyPI. This approach allows us to version and distribute the SDK without treating it as a standalone product.

## Python release process
- New Versioning Scheme: Python SDK tags will now follow a composite format, sdks/python/v[SDK_VERSION]-core.[CORE_VERSION], to link each SDK release directly to the version of the core Go executable it wraps.
  - Core Go Executable Tag: v[CORE_VERSION] (Example: v0.2.8)
  - Python SDK Tag: sdks/python/v[SDK_VERSION]-core.[CORE_VERSION] (Example: sdks/python/v0.1.0-core.0.2.8)

- Automated Release Workflow: A new GitHub Actions workflow (release-python-sdk.yml) triggers automatically when a tag matching sdks/python/v* is pushed.
  - The workflow builds the Python wheel (.whl).
  - It creates a new draft GitHub Release.
  - The built wheel is attached as a release asset.

And we then set up the a release workflow that looks for tag that start with `sdks/python/v`, and build the artifact attach to a draft release. 

## Usage
Users can now install a specific version of the Python SDK directly from GitHub Releases using 
```
pip install https://github.com/google/test-server/releases/download/[TAG]/[WHEEL_FILE_NAME].whl
```
Example
```
pip install https://github.com/google/test-server/releases/download/sdks/python/v0.1.0-core.0.2.7/test_server_sdk-0.1.0-py3-none-any.whl 
```


## Test:

Since the we used a fork method, the build actually trigged on my fork. Once this is merged, the tag will trigger the release on upstream.

### Create a release
```
git tag sdks/python/v0.1.0-core.0.2.7-test
git push origin sdks/python/v0.1.0-core.0.2.7-test
```
### Successfully triggered the build on pushing the tag
<img width="1274" height="84" alt="Screenshot 2025-09-10 at 8 31 00 PM" src="https://github.com/user-attachments/assets/d23cb5b2-7500-4694-9a80-4e17e2e870f2" />

### Build finish successfully
<img width="1282" height="83" alt="Screenshot 2025-09-10 at 8 31 56 PM" src="https://github.com/user-attachments/assets/5e42cabb-4e2f-43c9-ae70-8364e8636310" />
<img width="1689" height="801" alt="Screenshot 2025-09-10 at 8 32 34 PM" src="https://github.com/user-attachments/assets/d0c2fe9a-0a2e-4701-83a8-be04665b6e9d" />

### Created draft release
<img width="1240" height="522" alt="Screenshot 2025-09-10 at 8 32 54 PM" src="https://github.com/user-attachments/assets/47d74422-84cf-484c-ac3b-91c27af19558" />

### Clean up the test
```
git push --delete origin sdks/python/v0.1.0-core.0.2.7-test
git tag -d sdks/python/v0.1.0-core.0.2.7-test
```


