### PR TITLE
feat: Enable dynamic subdirectory recording paths in the test server

### DIFF
--- a/internal/record/recording_https_proxy.go
+++ b/internal/record/recording_https_proxy.go
@@ -203,6 +203,11 @@ func (r *RecordingHTTPSProxy) recordResponse(recReq *store.RecordedRequest, resp
 
 	recordPath := filepath.Join(r.recordingDir, fileName+".json")
 
+	recordDir := filepath.Dir(recordPath)
+    if err := os.MkdirAll(recordDir, 0755); err != nil {
+        return err
+    }
+
 	// Default to overwriting the file.
 	fileMode := os.O_TRUNC
 	file, err := os.OpenFile(recordPath, fileMode|os.O_CREATE|os.O_WRONLY, 0644)

--- a/sdks/python/sample/test-data/recordings/models/folder1/folder2/python-sample-test_recursive_path.json
+++ b/sdks/python/sample/test-data/recordings/models/folder1/folder2/python-sample-test_recursive_path.json
@@ -1,5 +1,5 @@
 {
-  "recordID": "models/python-sample-test",
+  "recordID": "models/folder1/folder2/python-sample-test_recursive_path",
   "interactions": [
     {
       "request": {
@@ -10,7 +10,7 @@
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
           "Connection": "keep-alive",
-          "Test-Name": "models/python-sample-test",
+          "Test-Name": "models/folder1/folder2/python-sample-test_recursive_path",
           "User-Agent": "python-requests/2.32.5"
         },
         "bodySegments": [
@@ -21,7 +21,7 @@
         "port": 443,
         "protocol": "https"
       },
-      "shaSum": "9748ed13d3c561f5cda29daf7725f77db500063c5568a672d22fc6284b38b813",
+      "shaSum": "79c8cd67ce0b39d6c5aeee4f685320e3066331e60171b49108251c3305cd034e",
       "response": {
         "statusCode": 200,
         "headers": {
@@ -31,16 +31,16 @@
           "Content-Language": "en-US",
           "Content-Security-Policy": "default-src 'none'; base-uri 'self'; child-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com wss://alive-staging.github.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com github.githubassets.com edge.fullstory.com rs.fullstory.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com www.youtube-nocookie.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com release-assets.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com marketplace-screenshots.githubusercontent.com/ copilotprodattachments.blob.core.windows.net/github-production-copilot-attachments/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com images.ctfassets.net/8aevphvgewt8/; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com github.githubassets.com assets.ctfassets.net/8aevphvgewt8/ videos.ctfassets.net/8aevphvgewt8/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/",
           "Content-Type": "text/html; charset=utf-8",
-          "Date": "Fri, 12 Sep 2025 14:58:06 GMT",
-          "Etag": "W/\"af9a9896f254fc84f4531204dbd30539\"",
+          "Date": "Mon, 15 Sep 2025 17:58:03 GMT",
+          "Etag": "W/\"cd488b2ea2ae9702b6652dfcb4294b9f\"",
           "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
           "Server": "github.com",
-          "Set-Cookie": "_gh_sess=c3pBIo%2Fl9xIciGbKk4ZVhxG0rJCAJRkAwy5r8f73h30JrKqHiV%2BL8SrUYhb%2FUKOvdh1ZDk8VsQ%2B2r9nOQYfekQlxDD7XGgmhXxiv%2FyUmKIgMkkFwzy%2BzAwKGozGt09ZeqUC84fWPu6dwb0NVt0KacusrqMGtYIBG23Rj7B9xJqqJ%2FKfosugusCMzdyRbtplYx%2B8yx%2FUheJUYTVmBRv8rZguwEqzolriAH4tstRrmR9C3k6BzxXvOIoxfHYRoBmqfYLd2%2FzrPEwvMoXWUaE%2FF%2Fg%3D%3D--KID3dtYrm8m6eNDP--ihdulT%2BadDTzU77BPNPGQA%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax, _octo=GH1.1.147291338.1757689093; Path=/; Domain=github.com; Expires=Sat, 12 Sep 2026 14:58:13 GMT; Secure; SameSite=Lax, logged_in=no; Path=/; Domain=github.com; Expires=Sat, 12 Sep 2026 14:58:13 GMT; HttpOnly; Secure; SameSite=Lax",
+          "Set-Cookie": "_gh_sess=3YXTN2Kn9fZ548MFymDvF4bmU3CVT1fhBeYO4rhAseW2l4rkmT0wzpD6sxgKPmt6uiXpcanTYQoSk0His54Z5ZVw1bPeaynC5BS5XzhvbMHfO4jT%2Ffg7udqglbBw1lmCRyr34q2WlFb%2F%2BM5aF3ErLwjPQUIHzxN1MH12fLFOxbh919Qvxs%2FEc%2FEdCQkb6a5wSvhYSihZXyGtDSQkRN%2FtE74aZZzOhn9hhHo68SeDmE47VCWIRm%2Bk1MGP3C6YiXwHjHF3T0%2Bu4OupJqUgKvKkbw%3D%3D--q7RzlJy371g%2FhXQu--2ZImD096TJjWHHRIqjJi%2Bg%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax, _octo=GH1.1.1334543195.1757959087; Path=/; Domain=github.com; Expires=Tue, 15 Sep 2026 17:58:07 GMT; Secure; SameSite=Lax, logged_in=no; Path=/; Domain=github.com; Expires=Tue, 15 Sep 2026 17:58:07 GMT; HttpOnly; Secure; SameSite=Lax",
           "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
           "Vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With, Accept-Language,Accept-Encoding, Accept, X-Requested-With",
           "X-Content-Type-Options": "nosniff",
           "X-Frame-Options": "deny",
-          "X-Github-Request-Id": "D82C:31F0BB:36700B3:37AB9F8:68C43505",
+          "X-Github-Request-Id": "D872:2A9986:920E617:96857F7:68C853AF",
           "X-Xss-Protection": "0"
         }
       }

--- a/sdks/python/sample/test-data/recordings/models/python-sample-test.json
+++ b/sdks/python/sample/test-data/recordings/models/python-sample-test.json
@@ -1,5 +1,5 @@
 {
-  "recordID": "396bab503f4b90ad88858bb4467d59b9e827dcd82e33f41c230e1b8fb43bdc8c",
+  "recordID": "models/python-sample-test",
   "interactions": [
     {
       "request": {
@@ -10,6 +10,7 @@
           "Accept": "*/*",
           "Accept-Encoding": "gzip, deflate",
           "Connection": "keep-alive",
+          "Test-Name": "models/python-sample-test",
           "User-Agent": "python-requests/2.32.5"
         },
         "bodySegments": [
@@ -20,7 +21,7 @@
         "port": 443,
         "protocol": "https"
       },
-      "shaSum": "396bab503f4b90ad88858bb4467d59b9e827dcd82e33f41c230e1b8fb43bdc8c",
+      "shaSum": "9748ed13d3c561f5cda29daf7725f77db500063c5568a672d22fc6284b38b813",
       "response": {
         "statusCode": 200,
         "headers": {
@@ -30,16 +31,16 @@
           "Content-Language": "en-US",
           "Content-Security-Policy": "default-src 'none'; base-uri 'self'; child-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com wss://alive-staging.github.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com github.githubassets.com edge.fullstory.com rs.fullstory.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com www.youtube-nocookie.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com release-assets.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com marketplace-screenshots.githubusercontent.com/ copilotprodattachments.blob.core.windows.net/github-production-copilot-attachments/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com images.ctfassets.net/8aevphvgewt8/; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com github.githubassets.com assets.ctfassets.net/8aevphvgewt8/ videos.ctfassets.net/8aevphvgewt8/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/",
           "Content-Type": "text/html; charset=utf-8",
-          "Date": "Tue, 09 Sep 2025 15:53:45 GMT",
-          "Etag": "W/\"8bab6ba1a0068ba77443041a70a012fc\"",
+          "Date": "Fri, 12 Sep 2025 14:58:06 GMT",
+          "Etag": "W/\"af9a9896f254fc84f4531204dbd30539\"",
           "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
           "Server": "github.com",
-          "Set-Cookie": "_gh_sess=jjLJMJHJa3yHLlB%2FstksHC7tyxHlTIGMZnISFDY5YvN2pZ40k9erSjDcL6N4fwiK3tI4gqB3ZMiFacRZPexRYU%2Fa4QKkFSyDN1oRGfv19gkqDJWH0UygUOc9239ontofFzh8rPEEnLdtPR3Jxq1Mb2sqs8e9MTvgTueqp1XRNElJvU3h0%2BocyQ%2Fr8XI4pIdLm64jp34ysCaisN%2FFXBa9SHzEIpGfQlrvihtWYcWP%2Bmzl0S5MAwox3%2BVFOiUPdf2AnD86OMXJekNHcxgzc41SPA%3D%3D--bex5KbZP2AtUtYXh--rcQmgTr4hiau78tUK896nQ%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax, _octo=GH1.1.1430909772.1757433231; Path=/; Domain=github.com; Expires=Wed, 09 Sep 2026 15:53:51 GMT; Secure; SameSite=Lax, logged_in=no; Path=/; Domain=github.com; Expires=Wed, 09 Sep 2026 15:53:51 GMT; HttpOnly; Secure; SameSite=Lax",
+          "Set-Cookie": "_gh_sess=c3pBIo%2Fl9xIciGbKk4ZVhxG0rJCAJRkAwy5r8f73h30JrKqHiV%2BL8SrUYhb%2FUKOvdh1ZDk8VsQ%2B2r9nOQYfekQlxDD7XGgmhXxiv%2FyUmKIgMkkFwzy%2BzAwKGozGt09ZeqUC84fWPu6dwb0NVt0KacusrqMGtYIBG23Rj7B9xJqqJ%2FKfosugusCMzdyRbtplYx%2B8yx%2FUheJUYTVmBRv8rZguwEqzolriAH4tstRrmR9C3k6BzxXvOIoxfHYRoBmqfYLd2%2FzrPEwvMoXWUaE%2FF%2Fg%3D%3D--KID3dtYrm8m6eNDP--ihdulT%2BadDTzU77BPNPGQA%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax, _octo=GH1.1.147291338.1757689093; Path=/; Domain=github.com; Expires=Sat, 12 Sep 2026 14:58:13 GMT; Secure; SameSite=Lax, logged_in=no; Path=/; Domain=github.com; Expires=Sat, 12 Sep 2026 14:58:13 GMT; HttpOnly; Secure; SameSite=Lax",
           "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
           "Vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With, Accept-Language,Accept-Encoding, Accept, X-Requested-With",
           "X-Content-Type-Options": "nosniff",
           "X-Frame-Options": "deny",
-          "X-Github-Request-Id": "D811:22D066:299B1F:2A4602:68C04D8F",
+          "X-Github-Request-Id": "D82C:31F0BB:36700B3:37AB9F8:68C43505",
           "X-Xss-Protection": "0"
         }
       }

--- a/sdks/python/sample/test-data/recordings/python-sample-test-single-name.json
+++ b/sdks/python/sample/test-data/recordings/python-sample-test-single-name.json
@@ -1,0 +1,49 @@
+{
+  "recordID": "python-sample-test-single-name",
+  "interactions": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "/",
+        "request": "GET / HTTP/1.1",
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "gzip, deflate",
+          "Connection": "keep-alive",
+          "Test-Name": "python-sample-test-single-name",
+          "User-Agent": "python-requests/2.32.5"
+        },
+        "bodySegments": [
+          null
+        ],
+        "previousRequest": "b4d6e60a9b97e7b98c63df9308728c5c88c0b40c398046772c63447b94608b4d",
+        "serverAddress": "github.com",
+        "port": 443,
+        "protocol": "https"
+      },
+      "shaSum": "1a786dc6d04c039bf6dac4945967c846dd1ffa978a1a7f7073014c19d6cdd131",
+      "response": {
+        "statusCode": 200,
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Cache-Control": "max-age=0, private, must-revalidate",
+          "Content-Encoding": "gzip",
+          "Content-Language": "en-US",
+          "Content-Security-Policy": "default-src 'none'; base-uri 'self'; child-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com www.githubstatus.com collector.github.com raw.githubusercontent.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com *.rel.tunnels.api.visualstudio.com wss://*.rel.tunnels.api.visualstudio.com objects-origin.githubusercontent.com copilot-proxy.githubusercontent.com proxy.individual.githubcopilot.com proxy.business.githubcopilot.com proxy.enterprise.githubcopilot.com *.actions.githubusercontent.com wss://*.actions.githubusercontent.com productionresultssa0.blob.core.windows.net/ productionresultssa1.blob.core.windows.net/ productionresultssa2.blob.core.windows.net/ productionresultssa3.blob.core.windows.net/ productionresultssa4.blob.core.windows.net/ productionresultssa5.blob.core.windows.net/ productionresultssa6.blob.core.windows.net/ productionresultssa7.blob.core.windows.net/ productionresultssa8.blob.core.windows.net/ productionresultssa9.blob.core.windows.net/ productionresultssa10.blob.core.windows.net/ productionresultssa11.blob.core.windows.net/ productionresultssa12.blob.core.windows.net/ productionresultssa13.blob.core.windows.net/ productionresultssa14.blob.core.windows.net/ productionresultssa15.blob.core.windows.net/ productionresultssa16.blob.core.windows.net/ productionresultssa17.blob.core.windows.net/ productionresultssa18.blob.core.windows.net/ productionresultssa19.blob.core.windows.net/ github-production-repository-image-32fea6.s3.amazonaws.com github-production-release-asset-2e65be.s3.amazonaws.com insights.github.com wss://alive.github.com wss://alive-staging.github.com api.githubcopilot.com api.individual.githubcopilot.com api.business.githubcopilot.com api.enterprise.githubcopilot.com github.githubassets.com edge.fullstory.com rs.fullstory.com; font-src github.githubassets.com; form-action 'self' github.com gist.github.com copilot-workspace.githubnext.com objects-origin.githubusercontent.com; frame-ancestors 'none'; frame-src viewscreen.githubusercontent.com notebooks.githubusercontent.com www.youtube-nocookie.com; img-src 'self' data: blob: github.githubassets.com media.githubusercontent.com camo.githubusercontent.com identicons.github.com avatars.githubusercontent.com private-avatars.githubusercontent.com github-cloud.s3.amazonaws.com objects.githubusercontent.com release-assets.githubusercontent.com secured-user-images.githubusercontent.com/ user-images.githubusercontent.com/ private-user-images.githubusercontent.com opengraph.githubassets.com marketplace-screenshots.githubusercontent.com/ copilotprodattachments.blob.core.windows.net/github-production-copilot-attachments/ github-production-user-asset-6210df.s3.amazonaws.com customer-stories-feed.github.com spotlights-feed.github.com objects-origin.githubusercontent.com *.githubusercontent.com images.ctfassets.net/8aevphvgewt8/; manifest-src 'self'; media-src github.com user-images.githubusercontent.com/ secured-user-images.githubusercontent.com/ private-user-images.githubusercontent.com github-production-user-asset-6210df.s3.amazonaws.com gist.github.com github.githubassets.com assets.ctfassets.net/8aevphvgewt8/ videos.ctfassets.net/8aevphvgewt8/; script-src github.githubassets.com; style-src 'unsafe-inline' github.githubassets.com; upgrade-insecure-requests; worker-src github.githubassets.com github.com/assets-cdn/worker/ github.com/assets/ gist.github.com/assets-cdn/worker/",
+          "Content-Type": "text/html; charset=utf-8",
+          "Date": "Mon, 15 Sep 2025 17:58:03 GMT",
+          "Etag": "W/\"cd488b2ea2ae9702b6652dfcb4294b9f\"",
+          "Referrer-Policy": "origin-when-cross-origin, strict-origin-when-cross-origin",
+          "Server": "github.com",
+          "Set-Cookie": "_gh_sess=w5DaXbsbx%2F2PlXqycHl0ShvuHiZnHqmL5iYuP%2FD59y8HvO9KC4xSzq9mDzz6ZnENbxpU8MNfwSO8l8kUlKs47gnCup9ikRBOw%2Fam%2FU53gJ0t0RZguRAbej9OLML8jl9A%2FVggEYSJYo1A4JGuEso3uDJMMlbmp2fw1uitkAsMrl2ExUMs35uptt4R1Z3tx631YsjOGz64QlW1MZWbHQzbM0hf3Kd98%2BXJopJnudZrfxesMw%2FyOoNEWclXZS7XDWN68XKAtQl7Nqq1kS4ShsuDPQ%3D%3D--vnkZeXNoz4iRMuQH--S4gx9ntAHwkRRafwzQrJhA%3D%3D; Path=/; HttpOnly; Secure; SameSite=Lax, _octo=GH1.1.831469942.1757959087; Path=/; Domain=github.com; Expires=Tue, 15 Sep 2026 17:58:07 GMT; Secure; SameSite=Lax, logged_in=no; Path=/; Domain=github.com; Expires=Tue, 15 Sep 2026 17:58:07 GMT; HttpOnly; Secure; SameSite=Lax",
+          "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",
+          "Vary": "X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, X-Requested-With, Accept-Language,Accept-Encoding, Accept, X-Requested-With",
+          "X-Content-Type-Options": "nosniff",
+          "X-Frame-Options": "deny",
+          "X-Github-Request-Id": "D872:2A9986:920E5EB:96857C2:68C853AF",
+          "X-Xss-Protection": "0"
+        }
+      }
+    }
+  ]
+}

--- a/sdks/python/sample/test_sample.py
+++ b/sdks/python/sample/test_sample.py
@@ -8,12 +8,29 @@ from pathlib import Path
 class TestSampleWithServer:
     """A test suite that requires the test-server to be running."""
 
-    def test_should_receive_200_from_proxied_github(self):
+    def test_should_receive_200_from_proxied_github_single_name(self):
         """Tests that a request to the proxy returns a successful response."""
         print("[PyTest] Making request to test-server proxy for www.github.com...")
 
         custom_headers = {
-            'Test-Name': 'models/python-sample-test',
+            'Test-Name': 'python-sample-test-single-name',
+        }   
+        
+        # Use the 'requests' library for a simpler HTTP call
+        response = requests.get("http://localhost:17080/", headers=custom_headers, timeout=10)
+
+        # Pytest uses simple 'assert' statements for checks
+        assert response.status_code == 200
+        assert "github" in json.dumps(dict(response.headers))
+        
+        print("[PyTest] Received 200 OK, content check passed.")
+    
+    def test_should_receive_200_from_proxied_github_recursive_path(self):
+        """Tests that a request to the proxy returns a successful response."""
+        print("[PyTest] Making request to test-server proxy for www.github.com...")
+
+        custom_headers = {
+            'Test-Name': 'models/folder1/folder2/python-sample-test_recursive_path',
         }   
         
         # Use the 'requests' library for a simpler HTTP call

--- a/sdks/python/sample/test_sample.py
+++ b/sdks/python/sample/test_sample.py
@@ -11,9 +11,13 @@ class TestSampleWithServer:
     def test_should_receive_200_from_proxied_github(self):
         """Tests that a request to the proxy returns a successful response."""
         print("[PyTest] Making request to test-server proxy for www.github.com...")
+
+        custom_headers = {
+            'Test-Name': 'models/python-sample-test',
+        }   
         
         # Use the 'requests' library for a simpler HTTP call
-        response = requests.get("http://localhost:17080/", timeout=10)
+        response = requests.get("http://localhost:17080/", headers=custom_headers, timeout=10)
 
         # Pytest uses simple 'assert' statements for checks
         assert response.status_code == 200


### PR DESCRIPTION
This change is required to accommodate the Python test suite's recording file directory structure.

Currently, our ~2000 Python tests organize recordings into module-specific subfolders. This structure is critical for maintainability and makes it easier to locate specific recording files.

To reduce test overhead and avoid duplicate pytest configurations, we use a single, session-scoped test server. The problem is that this server only accepts one root record_dir configuration when it starts, which would result in all 2,000 recordings being saved into one flat directory.

This pr implementing the logic needed for the single-session server to correctly generate test recordings into their appropriate, module-specific subdirectories.

Behavior:
- When the directory exist: nothing would happen
- When the directory exist: create the directory

Tested with the python test-server sample, attached the change.