### PR TITLE
feat: Add .NET 6.0 multi-targeting support to .NET SDK

### DIFF
--- a/sdks/dotnet/TestServerSdk.cs
+++ b/sdks/dotnet/TestServerSdk.cs
@@ -27,12 +27,12 @@ namespace TestServerSdk
 {
   public class TestServerOptions
   {
-    public required string ConfigPath { get; set; }
-    public required string RecordingDir { get; set; }
-    public required string Mode { get; set; } // "record" or "replay"
-    public required string BinaryPath { get; set; }
+    public string ConfigPath { get; set; } = "";
+    public string RecordingDir { get; set; } = "";
+    public string Mode { get; set; } = ""; // "record" or "replay"
+    public string BinaryPath { get; set; } = "";
 
-    public string TestServerSecrets { get; set; }
+    public string? TestServerSecrets { get; set; }
 
     public Action<string>? OnStdOut { get; set; }
     public Action<string>? OnStdErr { get; set; }

--- a/sdks/dotnet/TestServerSdk.csproj
+++ b/sdks/dotnet/TestServerSdk.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     
-    <PackageVersion>0.1.3</PackageVersion>
+    <PackageVersion>0.1.4</PackageVersion>
     <Authors>Google LLC</Authors>
     <Description>A .NET SDK to manage the test-server process for integration testing.</Description>
     <PackageProjectUrl>https://github.com/google/test-server</PackageProjectUrl>


### PR DESCRIPTION
- Add net6.0 as additional target framework alongside net8.0
- Remove 'required' keyword from TestServerOptions properties for .NET 6.0 compatibility
- Bump version to 0.1.4
- Use default empty string initialization instead of required properties

This enables the SDK to work with both .NET 6.0 and .NET 8.0 projects.