### PR TITLE
.NET: Add `netstandard2.0` support

### DIFF
--- a/sdks/dotnet/.editorconfig
+++ b/sdks/dotnet/.editorconfig
@@ -1,0 +1,26 @@
+[*.cs]
+# Rule: Remove unused using directives
+# Setting severity to 'suggestion', 'warning', or 'error' will enable the analyzer.
+# Code cleanup tools (like in Visual Studio or `dotnet format`) can then remove them.
+# 'silent' would still report it for `dotnet format` but not show in IDE as a squiggle.
+# 'none' would disable the check entirely.
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
+csharp_preferred_using_directive_placement = outside_namespace
+indent_size = 2
+
+# Suppressed above diagnostics for all .cs files
+dotnet_diagnostic.CS8604.severity = none
+dotnet_diagnostic.IDE0005.severity = none
+dotnet_diagnostic.IDE0011.severity = none
+dotnet_diagnostic.IDE1006.severity = none
+dotnet_diagnostic.IDE2000.severity = none
+dotnet_diagnostic.IDE2002.severity = none
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8602.severity = none
+dotnet_diagnostic.IDE0009.severity = none
+dotnet_diagnostic.IDE0017.severity = none
+dotnet_diagnostic.IDE0028.severity = none
+dotnet_diagnostic.CS8603.severity = none
+dotnet_diagnostic.CS8424.severity = none
+dotnet_diagnostic.CS0108.severity = none

--- a/sdks/dotnet/BinaryInstaller.cs
+++ b/sdks/dotnet/BinaryInstaller.cs
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-using System;
-using System.IO;
-using System.Net.Http;
+using SharpCompress.Common;
+using SharpCompress.Readers;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-using System.Diagnostics;
-using SharpCompress.Readers;
-using SharpCompress.Common;
-using System.Reflection;
 
 namespace TestServerSdk
 {
@@ -154,7 +150,11 @@ namespace TestServerSdk
     {
       using var stream = File.OpenRead(filePath);
       using var sha = SHA256.Create();
+#if NET6_0_OR_GREATER
       var hash = await sha.ComputeHashAsync(stream);
+#else
+      var hash = sha.ComputeHash(stream);
+#endif
       return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
     }
 
@@ -163,7 +163,11 @@ namespace TestServerSdk
       Console.WriteLine($"[TestServerSDK] Extracting {archivePath} to {destDir}...");
       if (archiveExt == ".zip")
       {
+#if NET6_0_OR_GREATER
         System.IO.Compression.ZipFile.ExtractToDirectory(archivePath, destDir, true);
+#else
+        System.IO.Compression.ZipFile.ExtractToDirectory(archivePath, destDir);
+#endif
       }
       else
       {

--- a/sdks/dotnet/TestServerSdk.csproj
+++ b/sdks/dotnet/TestServerSdk.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
-	  <PackageReference Include="SharpCompress" Version="0.29.0" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />
   </ItemGroup>
   <ItemGroup>

--- a/sdks/dotnet/TestServerSdk.csproj
+++ b/sdks/dotnet/TestServerSdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -20,6 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
+	  <PackageReference Include="SharpCompress" Version="0.29.0" />
     <PackageReference Include="SharpCompress" Version="0.29.0" />
   </ItemGroup>
   <ItemGroup>
@@ -33,4 +34,9 @@
     <EmbeddedResource Remove="tools/**" />
     <None Remove="tools/**" />
   </ItemGroup>
+	
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	<PackageReference Include="System.Text.Json" Version="8.0.6" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This is a pre-requisite to be able to test `netstandard2.0` projects for `Google.GenAI`.

- Partially resolves https://github.com/googleapis/dotnet-genai/issues/89